### PR TITLE
Refactor EKS configuration by commenting out unused security group ru…

### DIFF
--- a/demo/7-eks/03-locals.tf
+++ b/demo/7-eks/03-locals.tf
@@ -8,28 +8,7 @@ locals {
   vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets = data.terraform_remote_state.vpc.outputs.private_subnets
 
-  # vpc_security_group_ids = [
-  #   data.terraform_remote_state.vpc.outputs.default_security_group_id,
-  #   data.terraform_remote_state.alb.outputs.security_group_id,
-  # ]
-
   node_security_group_additional_rules = {
-    # ingress_all_self_node = {
-    #   description = "Node to node all"
-    #   protocol    = "-1"
-    #   from_port   = 0
-    #   to_port     = 0
-    #   type        = "ingress"
-    #   self        = true
-    # }
-    # ingress_all_self_cluster = {
-    #   description                   = "Cluster API to node all"
-    #   protocol                      = "-1"
-    #   from_port                     = 0
-    #   to_port                       = 0
-    #   type                          = "ingress"
-    #   source_cluster_security_group = true
-    # }
     ingress_cluster_15017_webhook = {
       description                   = "Cluster API to node 15017/tcp webhook"
       protocol                      = "tcp"

--- a/demo/7-eks/30-eks.tf
+++ b/demo/7-eks/30-eks.tf
@@ -11,7 +11,6 @@ module "eks" {
   vpc_id     = local.vpc_id
   subnet_ids = local.private_subnets
 
-  # ipv6
   cluster_ip_family          = var.ip_family
   create_cni_ipv6_iam_policy = var.ip_family == "ipv6" ? true : false
 

--- a/demo/7-eks/terraform.tfvars
+++ b/demo/7-eks/terraform.tfvars
@@ -6,3 +6,10 @@ cluster_version = "1.31"     # cluster_version for eks-demo
 ip_family = "ipv4" # ipv4, ipv6
 
 key_name = "bruce-seoul"
+
+self_managed_node_groups = {
+  workers = {
+    group         = "workers"
+    instance_type = "c6i.xlarge"
+  }
+}


### PR DESCRIPTION
…les and removing deprecated IPv6 settings. Introduce self-managed node group configuration in terraform.tfvars for improved clarity and maintainability of the setup.